### PR TITLE
fix in scale option for "death by age range" chart to begin Y axe at zero

### DIFF
--- a/assets/js/charts/charts-deaths.js
+++ b/assets/js/charts/charts-deaths.js
@@ -68,6 +68,13 @@ function chart(chartData, lang) {
     ctx = document.getElementById('chart-deaths-new');
     if (ctx) {
         options = createDefaultChartOptions();
+        options.scales = {
+            yAxes: [{
+                ticks: {
+                    beginAtZero: true,
+                }
+            }]
+        }
         new Chart(ctx, {
             type: 'bar',
             data: {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
         "gulp-purgecss": "^4.0.3",
         "gulp-replace": "^1.1.3",
         "gulp-sass": "^4.1.0",
+        "hugo": "^0.0.3",
         "js-cookie": "^2.2.1",
         "mocha": "^8.4.0",
         "moment": "^2.29.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
         "gulp-purgecss": "^4.0.3",
         "gulp-replace": "^1.1.3",
         "gulp-sass": "^4.1.0",
-        "hugo": "^0.0.3",
         "js-cookie": "^2.2.1",
         "mocha": "^8.4.0",
         "moment": "^2.29.1",


### PR DESCRIPTION
Hey Juan, thanks for sharing this cool project, I've visited the site during months in a regular basis.
I've recently realized the chart of deaths by age range was starting its y axes at 400 which gave me a false sensation of low risk at 0-49 range.
I've also added Hugo in dependencies because I needed it to run locally.
Feel free to merge.
Gracias!